### PR TITLE
Added Light Switch Status Bar Item

### DIFF
--- a/src/commands/binder.ts
+++ b/src/commands/binder.ts
@@ -1,7 +1,14 @@
 // The command has been defined in the package.json file
 // Now provide the implementation of the command with registerCommand
 // The commandId parameter must match the command field in package.json
-import { ExtensionContext, Disposable, commands } from 'vscode';
+import {
+  ExtensionContext,
+  Disposable,
+  commands,
+  window,
+  StatusBarAlignment,
+  StatusBarItem
+} from 'vscode';
 import switchThemes from './switch';
 import setTheme from './setTheme';
 
@@ -30,4 +37,23 @@ export function registerCommandSetThemeDay(
   return registerCommand('setDayTheme', () => {
     setTheme(context, true);
   });
+}
+
+/**
+ * Creates and returns the Light Switch Status Bar Item
+ *
+ * Note: The returned StatusBarItem still needs to be pushed into vscode's subscriptions
+ */
+export function createLightSwitchStatusBarItem(): StatusBarItem {
+  const statusBarItem = window.createStatusBarItem(
+    StatusBarAlignment.Left,
+    100 // The higher the number the farther left it is on the status bar
+  );
+
+  statusBarItem.command = `lightSwitch.toggleThemess`;
+  statusBarItem.text = '$(light-bulb) Light Switch'; // $(light-bulb) renders a ligh-bulb icon on the status bar before the text
+  statusBarItem.tooltip = 'Toggle Themes';
+  statusBarItem.show();
+
+  return statusBarItem;
 }

--- a/src/commands/binder.ts
+++ b/src/commands/binder.ts
@@ -11,6 +11,7 @@ import {
 } from 'vscode';
 import switchThemes from './switch';
 import setTheme from './setTheme';
+import { Constants } from '../util/constants';
 
 function registerCommand(id: string, func: any): Disposable {
   const command = commands.registerCommand(`lightSwitch.${id}`, func);
@@ -18,7 +19,7 @@ function registerCommand(id: string, func: any): Disposable {
 }
 
 export function registerCommandSwitch(context: ExtensionContext): Disposable {
-  return registerCommand('toggleThemes', () => {
+  return registerCommand(Constants.TOGGLE_THEMES_COMMAND_ID, () => {
     switchThemes(context);
   });
 }
@@ -45,12 +46,12 @@ export function registerCommandSetThemeDay(
  * Note: The returned StatusBarItem still needs to be pushed into vscode's subscriptions
  */
 export function createLightSwitchStatusBarItem(): StatusBarItem {
-  const statusBarItem = window.createStatusBarItem(
+  const statusBarItem: StatusBarItem = window.createStatusBarItem(
     StatusBarAlignment.Left,
-    100 // The higher the number the farther left it is on the status bar
+    Constants.STATUS_BAR_PRIORITY
   );
 
-  statusBarItem.command = `lightSwitch.toggleThemess`;
+  statusBarItem.command = `${Constants.LIGHT_SWITCH}.${Constants.TOGGLE_THEMES_COMMAND_ID}`;
   statusBarItem.text = '$(light-bulb) Light Switch'; // $(light-bulb) renders a ligh-bulb icon on the status bar before the text
   statusBarItem.tooltip = 'Toggle Themes';
   statusBarItem.show();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,6 +26,8 @@ export function activate(context: ExtensionContext) {
   setInterval((): void => {
     setTheme(context, canSwitchToNightTheme());
   }, interval);
+
+  context.subscriptions.push(binder.createLightSwitchStatusBarItem());
 }
 
 // this method is called when your extension is deactivated

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -2,5 +2,7 @@ export const Constants = Object.freeze({
   THEME_DAY: 'themeDay',
   LIGHT_SWITCH: 'lightSwitch',
   INTERVAL_MINUTES: 10,
-  INTERVAL_FORMULA: 60 * 1000
+  INTERVAL_FORMULA: 60 * 1000,
+  TOGGLE_THEMES_COMMAND_ID: 'toggleThemes',
+  STATUS_BAR_PRIORITY: 100 // The higher the number the farther left it is on the status bar
 });


### PR DESCRIPTION

It was mentioned in #12 that it would be nice to have a GUI tool to switch themes. This PR implements a statusBarItem that when clicked calls the toggleThemes command switching the user's themes.

Here's a screenshot of the statusBarItem. I have it positioned on the far left. Let me know if it should a different icon/text or be positioned differently! The available icons can be found [here](https://code.visualstudio.com/api/references/icons-in-labels#grid-listing).

![image](https://user-images.githubusercontent.com/17183431/67136504-0a15e780-f1f5-11e9-8191-bfc8f19ad4c0.png)
