### PR TITLE
Fix extension.ts setInterval call

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,7 +22,7 @@ export function activate(context: ExtensionContext) {
   const interval = Constants.INTERVAL_MINUTES * Constants.INTERVAL_FORMULA;
 
   setInterval((): void => {
-    setTheme(context, canSwitchToNightTheme());
+    setTheme(context, !canSwitchToNightTheme());
   }, interval);
 
   context.subscriptions.push(binder.createLightSwitchStatusBarItem());


### PR DESCRIPTION
`setTheme` accepts the argument `dayTheme`, and we're passing `canSwitchToNightTheme`, which determines if we can switch to the dark theme. Therefore the logic is reversed.