### PR TITLE
Update azure-pipelines.yml for Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,13 +27,14 @@ steps:
         VERSION_STRING=${PACKAGE_VERSION}-ci-$(git rev-parse --short HEAD)
       fi
 
-      npm --no-git-tag-version version $VERSION_STRING
+      # npm --no-git-tag-version version $VERSION_STRING
+      echo ">>> Build Version"
       echo "##vso[build.updatebuildnumber]${VERSION_STRING}_${BUILD_BUILDID}"
+      echo ">>> Package Version"
       echo "$PACKAGE_VERSION" > version.txt
     displayName: Set version number of package and build
 
   - bash: |
-      echo ">>> Run integration test"
       yarn && yarn compile && yarn test
     displayName: Run Tests
     env:


### PR DESCRIPTION
Remove `npm --no-git-tag-version version $VERSION_STRING`. This is changing the `package.json` version number, and thus conflicting with the actual version of the extension.